### PR TITLE
error in initial update of this.state.ruleset doesn't crash client

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,9 @@ Client.prototype.sync = function (callback) {
   if (!this.state.ruleset) {
     this.state.ruleset = ledgerPublisher.rules
 
-    this._updateRules(function (err) { if (err) this._log('updateRules', { message: err.toString() }) })
+    this._updateRules(function (err) {
+      if (err) this._log('updateRules', { message: err.toString() })
+    }.bind(this))
   }
 
   if (this.state.rulesStamp < now) {

--- a/index.js
+++ b/index.js
@@ -54,9 +54,7 @@ Client.prototype.sync = function (callback) {
   if (!this.state.ruleset) {
     this.state.ruleset = ledgerPublisher.rules
 
-    this._updateRules(function (err) {
-      if (err) this._log('updateRules', { message: err.toString() })
-    }.bind(this))
+    this._updateRules(function (err) { if (err) self._log('updateRules', { message: err.toString() })})
   }
 
   if (this.state.rulesStamp < now) {


### PR DESCRIPTION
When `Client#sync` can't fetch `this.state.ruleset` using `Client#_updateRules` the error handler was calling `this._log` when `this` was not bound to the Client instance and crashing (client/brave). Just added `.bind(this)` to fix.

fixes https://github.com/brave/ledger-client/commit/d38a8bc67d8c1d82885aac2c2cf427b47c378389#commitcomment-19057449