### PR TITLE
Helper methods for summarizing contributions and CSV export (browser-laptop#3477)

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,9 @@ Client.prototype.sync = function (callback) {
   if (!this.state.ruleset) {
     this.state.ruleset = ledgerPublisher.rules
 
-    this._updateRules(function (err) { if (err) this._log('updateRules', { message: err.toString() }) })
+    this._updateRules(function (err) {
+      if (err) this._log('updateRules', { message: err.toString() })
+    }.bind(this))
   }
 
   if (this.state.rulesStamp < now) {


### PR DESCRIPTION
Adds CSV export for ledger transaction/contribution data by publisher
  supports brave/browser-laptop#3477
  needed for PR https://github.com/brave/browser-laptop/pull/4312

A couple contribution summary helper methods:

- Client#_publisherVoteData([viewingIds])
  get a contribution summary organized by publisher for 1, N (an array), or all transactions
  (useful for brave/browser-laptop#3477)

- Client#_totalContribution([viewingIds])
  get the total amount contributed in BTC and fiat for 1, N (an array), or all transactions

- Client#_transactionByViewingId(viewingId) (self-explanatory)