### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/blastoff.js
+++ b/blastoff.js
@@ -3,7 +3,7 @@
 var fs = require('fs')
 var path = require('path')
 var url = require('url')
-var uuid = require('node-uuid')
+var uuid = require('uuid')
 
 /*
  *

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var random = require('random-lib')
 var underscore = require('underscore')
 var url = require('url')
 var util = require('util')
-var uuid = require('node-uuid')
+var uuid = require('uuid')
 
 var Client = function (personaId, options, state) {
   if (!(this instanceof Client)) return new Client(personaId, options, state)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An example of client code for the Brave ledger.",
   "main": "index.js",
   "scripts": {
-    "blastoff":  "DEBUG=*,-babel ./blastoff.js -d -l -v -s http://127.0.0.1:3001 -p `uuidgen`",
+    "blastoff": "DEBUG=*,-babel ./blastoff.js -d -l -v -s http://127.0.0.1:3001 -p `uuidgen`",
     "touchdown": "DEBUG=*,-babel ./blastoff.js -d -l -v -s http://127.0.0.1:3001 -f ./config.json",
     "lint": "standard",
     "test": "npm run test-security",
@@ -25,9 +25,9 @@
     "joi": "^9.0.0-2",
     "ledger-publisher": "^0.8.90",
     "node-anonize2-relic-emscripten": "https://github.com/brave/node-anonize2-relic-emscripten.git",
-    "node-uuid": "^1.4.7",
     "random-lib": "2.1.0",
-    "underscore": "1.8.3"
+    "underscore": "1.8.3",
+    "uuid": "^3.0.0"
   },
   "engines": {
     "node": ">= 6.1.0",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.